### PR TITLE
Fix singleton injection and make CI report real test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          file: ./build/coverage.xml
           flags: pyiv
           name: codecov-pyiv-${{ matrix.python-version }}
           fail_ci_if_error: false
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bandit-security-report-${{ matrix.python-version }}
-          path: bandit-report.json
+          path: build/bandit-report.json
           if-no-files-found: ignore
 
       - name: Upload coverage HTML report
@@ -85,7 +85,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html-report-${{ matrix.python-version }}
-          path: htmlcov/
+          path: build/htmlcov/
           if-no-files-found: ignore
 
       - name: Build distribution packages (verify build)

--- a/pyiv/command.py
+++ b/pyiv/command.py
@@ -229,11 +229,14 @@ class CLICommand(Command):
 
     Provides a simplified lifecycle for commands that execute and exit:
     1. init() - Optional initialization
-    2. execute() - Main command logic (subclasses override this)
+    2. run() - Main command logic (subclasses override this)
     3. cleanup() - Optional cleanup
 
-    Subclasses should override execute() to implement command logic.
-    For commands that need init/run/cleanup, override those methods instead.
+    Subclasses should override run() (and optionally init()/cleanup()).
+    Set self._exit_code in run() to return a non-zero status.
+
+    Do not override execute() — it implements the lifecycle, KeyboardInterrupt
+    handling (exit 130), and SystemExit handling.
     """
 
     def __init__(self, args: argparse.Namespace, injector: Optional[Any] = None):
@@ -248,7 +251,8 @@ class CLICommand(Command):
     def run(self) -> None:
         """Run the CLI command (no-op by default).
 
-        For CLI commands, implement execute() directly instead of run().
+        Override this method to implement command logic. Set self._exit_code
+        to return a non-zero status from execute().
         """
         self._exit_code = 0
 

--- a/pyiv/injector.py
+++ b/pyiv/injector.py
@@ -93,68 +93,12 @@ class Injector:
         if provider is not None:
             return provider.get()
 
-        # Check for Scope
+        # Check for Scope (singleton=True / singleton_type also install a Scope)
         scope = self._config.get_scope(cls)
         if scope is not None and not isinstance(scope, NoScope):
             return self._inject_scoped(cls, scope, **kwargs)
 
-        # Fall back to singleton type (backward compatibility)
-        singleton_type = self._config.get_singleton_type(cls)
-
-        # Handle global singleton
-        if singleton_type == SingletonType.GLOBAL_SINGLETON:
-            instance = GlobalSingletonRegistry.get(cls)
-            if instance is not None:
-                return instance
-            # Create new instance and store globally
-            concrete = self._config.get_registration(cls)
-            if concrete is None:
-                instance = self._instantiate(cls, **kwargs)
-            else:
-                instance = self._instantiate(concrete, **kwargs)
-            GlobalSingletonRegistry.set(cls, instance)
-            return instance
-
-        # Check if we have a registered singleton instance
-        instance = self._config.get_instance(cls)
-        if instance is not None:
-            return instance
-
-        # Check if we have a cached per-injector singleton
-        if singleton_type == SingletonType.SINGLETON and cls in self._singletons:
-            return self._singletons[cls]
-
-        # Get the concrete implementation
-        concrete = self._config.get_registration(cls)
-
-        if concrete is None:
-            # No registration, try to instantiate the class directly
-            # (useful for concrete classes that don't need registration)
-            instance = self._instantiate(cls, **kwargs)
-            # Store as singleton if configured
-            if singleton_type == SingletonType.SINGLETON:
-                self._singletons[cls] = instance
-            return instance
-
-        # Check if it's a lazy singleton registration (old style)
-        if cls in self._config._instances and self._config._instances[cls] is None:
-            # Lazy singleton creation
-            instance = self._instantiate(concrete, **kwargs)
-            self._singletons[cls] = instance
-            self._config._instances[cls] = instance
-            return instance
-
-        # Instantiate the concrete implementation
-        instance = self._instantiate(concrete, **kwargs)
-
-        # Store as singleton if configured
-        if singleton_type == SingletonType.SINGLETON:
-            self._singletons[cls] = instance
-        elif cls in self._config._instances:
-            # Old-style singleton caching
-            self._singletons[cls] = instance
-
-        return instance
+        return self._create_unscoped(cls, **kwargs)
 
     def _inject_key(self, key: Key[Any], **kwargs) -> Any:
         """Inject using a qualified key.
@@ -207,14 +151,12 @@ class Injector:
         if cls in scope_cache:
             return scope_cache[cls]
 
-        # Create provider
-        provider = InjectorProvider(cls, self)
+        # Instantiate without calling inject() again. InjectorProvider.get()
+        # calls inject(), which re-enters this method and recurses/deadlocks.
+        unscoped = _UnscopedProvider(lambda: self._instantiate_registered(cls, **kwargs))
 
-        # Apply scope - convert cls to Key type for scope
         scope_key: Union[Type, str, tuple] = cls
-        scoped_provider = scope.scope(scope_key, provider)
-
-        # Get instance
+        scoped_provider = scope.scope(scope_key, unscoped)
         instance = scoped_provider.get()
 
         # Cache if scope supports it (for per-injector scopes)
@@ -222,6 +164,55 @@ class Injector:
             scope_cache[cls] = instance
 
         return instance
+
+    def _create_unscoped(self, cls: Type, **kwargs) -> Any:
+        """Create an instance when no Scope applies.
+
+        Honors singleton_type / GlobalSingletonRegistry for registrations that
+        did not install a Scope. Constructor dependencies still go through
+        `inject()` via `_instantiate`.
+        """
+        singleton_type = self._config.get_singleton_type(cls)
+
+        # Handle global singleton (when no Scope was installed)
+        if singleton_type == SingletonType.GLOBAL_SINGLETON:
+            instance = GlobalSingletonRegistry.get(cls)
+            if instance is not None:
+                return instance
+            concrete = self._config.get_registration(cls)
+            if concrete is None:
+                instance = self._instantiate(cls, **kwargs)
+            else:
+                instance = self._instantiate(concrete, **kwargs)
+            GlobalSingletonRegistry.set(cls, instance)
+            return instance
+
+        instance = self._config.get_instance(cls)
+        if instance is not None:
+            return instance
+
+        if singleton_type == SingletonType.SINGLETON and cls in self._singletons:
+            return self._singletons[cls]
+
+        instance = self._instantiate_registered(cls, **kwargs)
+
+        if singleton_type == SingletonType.SINGLETON:
+            self._singletons[cls] = instance
+        elif cls in self._config._instances:
+            self._singletons[cls] = instance
+
+        return instance
+
+    def _instantiate_registered(self, cls: Type, **kwargs) -> Any:
+        """Instantiate the registered concrete (or `cls`) with no lifecycle caching."""
+        instance = self._config.get_instance(cls)
+        if instance is not None:
+            return instance
+
+        concrete = self._config.get_registration(cls)
+        if concrete is None:
+            return self._instantiate(cls, **kwargs)
+        return self._instantiate(concrete, **kwargs)
 
     def _instantiate(self, concrete: Union[Type, Callable[..., Any]], **kwargs) -> Any:
         """Instantiate a class or call a factory function.
@@ -642,6 +633,16 @@ class Injector:
         if args:
             return args[0]
         return None
+
+
+class _UnscopedProvider:
+    """Provider that calls a factory once without going through `inject()`."""
+
+    def __init__(self, factory: Callable[[], Any]):
+        self._factory = factory
+
+    def get(self) -> Any:
+        return self._factory()
 
 
 def get_injector(config: Union[Type[Config], Config]) -> Injector:

--- a/pyiv/scope.py
+++ b/pyiv/scope.py
@@ -194,7 +194,7 @@ class SingletonScope:
 
     def __init__(self):
         """Initialize the singleton scope."""
-        self._instances: Dict[Key, Any] = {}
+        self._instances: Dict[Any, Any] = {}
 
     def scope(self, key: Key, provider: Provider[Any]) -> Provider[Any]:
         """Scope provider to per-injector singleton.
@@ -241,7 +241,7 @@ class GlobalSingletonScope:
     """
 
     _lock = threading.Lock()
-    _instances: Dict[Key, Any] = {}
+    _instances: Dict[Any, Any] = {}
 
     def scope(self, key: Key, provider: Provider[Any]) -> Provider[Any]:
         """Scope provider to global singleton.
@@ -260,10 +260,18 @@ class GlobalSingletonScope:
                 self._provider = provider
 
             def get(self) -> Any:
+                # Look up under the lock, but construct outside it. Holding the
+                # lock during provider.get() deadlocks when a global singleton
+                # depends on another global singleton (same class-level lock).
                 with GlobalSingletonScope._lock:
-                    if self._key not in GlobalSingletonScope._instances:
-                        GlobalSingletonScope._instances[self._key] = self._provider.get()
-                    return GlobalSingletonScope._instances[self._key]
+                    if self._key in GlobalSingletonScope._instances:
+                        return GlobalSingletonScope._instances[self._key]
+                instance = self._provider.get()
+                with GlobalSingletonScope._lock:
+                    if self._key in GlobalSingletonScope._instances:
+                        return GlobalSingletonScope._instances[self._key]
+                    GlobalSingletonScope._instances[self._key] = instance
+                    return instance
 
         return ScopedProvider(key, provider)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,14 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 
+[tool.coverage.run]
+source = ["pyiv"]
+branch = false
+
+[tool.coverage.report]
+fail_under = 60
+show_missing = true
+
 [tool.black]
 line-length = 100
 target-version = ["py38", "py39", "py310", "py311", "py312"]

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -62,11 +62,9 @@ run_check "isort import sorting" $ISORT_CMD --check-only pyiv/ tests/
 # 3. Pytest with coverage
 # Create build directory if it doesn't exist
 mkdir -p build
-# Skip html report to avoid permission issues with htmlcov directory
-# Exit code 2 from pytest-cov is acceptable (coverage collection succeeded, html report may fail)
-$PYTEST_CMD --cov=pyiv --cov-report=xml:build/coverage.xml --cov-report=term-missing tests/ 2>&1
+$PYTEST_CMD --cov=pyiv --cov-report=xml:build/coverage.xml --cov-report=term-missing tests/
 PYTEST_EXIT=$?
-if [ $PYTEST_EXIT -eq 0 ] || [ $PYTEST_EXIT -eq 2 ]; then
+if [ $PYTEST_EXIT -eq 0 ]; then
     echo -e "${GREEN}✓ Pytest with coverage passed${NC}"
 else
     echo -e "${RED}✗ Pytest with coverage failed (exit code: $PYTEST_EXIT)${NC}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Pytest configuration and fixtures for console tests."""
+"""Pytest configuration and fixtures."""
 
 import os
 import pty
@@ -11,6 +11,19 @@ def pytest_configure(config):
     """Configure pytest markers."""
     config.addinivalue_line("markers", "tty: mark test as requiring TTY (will use PTY for testing)")
     config.addinivalue_line("markers", "integration: mark test as integration test")
+
+
+@pytest.fixture(autouse=True)
+def _clear_global_singletons():
+    """Reset process-wide singleton caches between tests."""
+    from pyiv.scope import GlobalSingletonScope
+    from pyiv.singleton import GlobalSingletonRegistry
+
+    GlobalSingletonRegistry.clear()
+    GlobalSingletonScope.clear()
+    yield
+    GlobalSingletonRegistry.clear()
+    GlobalSingletonScope.clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -14,6 +14,17 @@ from pyiv.command import CLICommand, Command, CommandRunner, ServiceCommand
 from pyiv.reflection import ReflectionConfig
 
 
+def _cleanup_imported_package(tmpdir: str, package_name: str = "test_package") -> None:
+    """Remove a temp package from sys.path and sys.modules after discovery tests."""
+    if tmpdir in sys.path:
+        sys.path.remove(tmpdir)
+    modules_to_remove = [
+        m for m in sys.modules if m == package_name or m.startswith(package_name + ".")
+    ]
+    for name in modules_to_remove:
+        del sys.modules[name]
+
+
 # Test command implementations (prefixed with Sample to avoid pytest collection)
 class SampleCommand(Command):
     """Sample command implementation."""
@@ -331,7 +342,7 @@ class TestCLICommand:
             def get_name(cls) -> str:
                 return "interrupt-cli"
 
-            def execute(self) -> int:
+            def run(self) -> None:
                 raise KeyboardInterrupt()
 
         args = argparse.Namespace()
@@ -347,7 +358,7 @@ class TestCLICommand:
             def get_name(cls) -> str:
                 return "system-exit-cli"
 
-            def execute(self) -> int:
+            def run(self) -> None:
                 raise SystemExit(99)
 
         args = argparse.Namespace()
@@ -363,14 +374,12 @@ class TestCLICommand:
             def get_name(cls) -> str:
                 return "default-exit"
 
-            def execute(self) -> int:
-                # Don't set _exit_code, should default to 0
-                return super().execute()
+            def run(self) -> None:
+                # Default _exit_code path via CLICommand.run()
+                super().run()
 
         args = argparse.Namespace()
         cmd = DefaultExitCLI(args)
-        # Override execute to not call super
-        cmd.run()  # This sets _exit_code to 0
         exit_code = cmd.execute()
         assert exit_code == 0
 
@@ -429,7 +438,7 @@ class TestCommand(Command):
                 assert "test" in commands
                 assert commands["test"].__name__ == "TestCommand"
             finally:
-                sys.path.remove(str(tmpdir))
+                _cleanup_imported_package(str(tmpdir))
 
     def test_discover_commands_with_reflection(self):
         """Test command discovery with reflection."""
@@ -494,7 +503,7 @@ class TestCommand(CLICommand):
                 )
                 assert exit_code == 0
             finally:
-                sys.path.remove(str(tmpdir))
+                _cleanup_imported_package(str(tmpdir))
 
     def test_run_command_not_found(self):
         """Test running a non-existent command."""
@@ -537,7 +546,7 @@ class TestCommand(CLICommand):
                         args=["unknown"],
                     )
             finally:
-                sys.path.remove(str(tmpdir))
+                _cleanup_imported_package(str(tmpdir))
 
     def test_run_command_keyboard_interrupt(self):
         """Test running a command that raises KeyboardInterrupt."""
@@ -563,7 +572,7 @@ class TestCommand(CLICommand):
     def get_description(cls) -> str:
         return "Test command"
     
-    def execute(self) -> int:
+    def run(self) -> None:
         raise KeyboardInterrupt()
 """
             )
@@ -579,7 +588,7 @@ class TestCommand(CLICommand):
                 )
                 assert exit_code == 130
             finally:
-                sys.path.remove(str(tmpdir))
+                _cleanup_imported_package(str(tmpdir))
 
     def test_register_commands_with_subcommands(self):
         """Test registering commands with subcommands."""
@@ -591,9 +600,10 @@ class TestCommand(CLICommand):
         commands = {"parent": SampleCommandWithSubcommands}
         runner._register_commands(subparsers, commands)
 
-        # Should be able to parse parent command
-        args = parser.parse_args(["parent"])
+        # Parent requires its subcommand ("test")
+        args = parser.parse_args(["parent", "test"])
         assert args.command == "parent"
+        assert args.subcommand == "test"
 
     def test_create_parser(self):
         """Test create_parser method."""
@@ -635,7 +645,7 @@ class TestCommandWithDI:
         )
 
         injector = MagicMock()
-        with patch("pyiv.command.get_injector", return_value=injector):
+        with patch("pyiv.get_injector", return_value=injector):
             runner = CommandRunner(config=config)
 
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -676,7 +686,7 @@ class TestCommand(CLICommand):
                     )
                     assert exit_code == 0
                 finally:
-                    sys.path.remove(str(tmpdir))
+                    _cleanup_imported_package(str(tmpdir))
 
 
 class TestCommandAliases:

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -184,6 +184,24 @@ class TestGlobalSingleton:
         db3 = injector2.inject(Database)
         assert db3 is db2
 
+    def test_global_singleton_can_depend_on_another(self):
+        """Global singletons must not deadlock when one depends on another."""
+
+        class App:
+            def __init__(self, db: Database):
+                self.db = db
+
+        class DepConfig(Config):
+            def configure(self):
+                self.register(Database, PostgreSQL, singleton_type=SingletonType.GLOBAL_SINGLETON)
+                self.register(App, App, singleton_type=SingletonType.GLOBAL_SINGLETON)
+
+        injector = get_injector(DepConfig)
+        app = injector.inject(App)
+        db = injector.inject(Database)
+        assert isinstance(app, App)
+        assert app.db is db
+
 
 class TestNoSingleton:
     """Test NONE singleton type (default behavior)."""


### PR DESCRIPTION
## Summary
- Fix scoped/singleton injection so `inject()` no longer recurses or deadlocks on global singletons.
- Stop treating pytest exit code 2 (interrupted run) as success, and point coverage/bandit artifact uploads at `build/`.
- Correct command tests so KeyboardInterrupt/SystemExit are raised from `run()` and temp packages do not leak into `sys.modules`.

## Test plan
- [x] `pytest tests/` — 209 passed locally
- [x] Coverage ~66% with a 60% floor
- [ ] Confirm GitHub Actions CI is green on 3.8–3.12
- [ ] Confirm a failing/interrupted pytest would now fail the workflow
