### PR TITLE
Keep PyPI, docs site, and release notes on one install story

### DIFF
--- a/.cursor/rules/packaging-docs.mdc
+++ b/.cursor/rules/packaging-docs.mdc
@@ -1,0 +1,18 @@
+---
+description: PyPI metadata, install claims, and GitHub release copy must match README and the docs site.
+globs: pyproject.toml,RELEASE.md,CHANGELOG.md,LICENSE,.github/workflows/release.yml,.github/workflows/version-bump.yml
+alwaysApply: false
+---
+
+# Packaging copy
+
+`[project]` in `pyproject.toml` is the PyPI sidebar. Keep it real:
+
+- Author and URLs must not be `Your Name` / `yourusername`.
+- `Documentation` = `https://rl337.org/pyiv/`
+- Homepage / Repository / Issues = `https://github.com/rl337/pyiv` (and `/issues`)
+- Description should match the README one-liner (Guice-style DI, not factory-first)
+
+Install commands in `RELEASE.md`, release workflow text, and GitHub Release bodies must match README. Until pyiv is on PyPI, that is the git URL, not `pip install pyiv` or `pip install pyiv==<version>`.
+
+Do not add a Changelog URL until `CHANGELOG.md` (or an equivalent site page) exists; then set it in `project.urls` and link it from the docs homepage.

--- a/.cursor/rules/website.mdc
+++ b/.cursor/rules/website.mdc
@@ -1,19 +1,19 @@
 ---
-description: README vs Sphinx site split, homepage features, and RTD sidebar toctrees.
+description: README vs Sphinx split, install story, homepage features, and RTD sidebar.
 globs: docs/**/*.rst,docs/**/*.md,docs/conf.py,README.md
 alwaysApply: false
 ---
 
 # Website and README
 
-**README.md** is the GitHub landing page only: what pyiv is, git install, a short quick start, link to https://rl337.org/pyiv/. Do not duplicate the API reference here.
+README is the GitHub **and** PyPI long description: what pyiv is, honest install, short quick start, link to https://rl337.org/pyiv/. Do not duplicate the API reference.
 
-**docs/** is the product site. Homepage Key Features must stay: type-based injection, scopes, keys/binder, reflection, test doubles, zero dependencies. Do not headline Factory. Do not claim PyPI or Poetry.
+**docs/** is the product site. Key Features: type-based injection, scopes, keys/binder, reflection, test doubles, zero dependencies. Do not headline Factory.
 
-Install instructions: `pip install git+https://github.com/rl337/pyiv.git` until a PyPI release exists.
+Install must match README and release notes. Until PyPI exists: `pip install git+https://github.com/rl337/pyiv.git`. No `pip install pyiv`, no PyPI project link, no Poetry.
 
-API navigation lives on `docs/index.rst` as grouped `toctree` directives (Core DI, Bindings, Discovery, Test doubles, Integrations) pointing at `docs/pyiv/pyiv.*.rst`. Do not rely on `modules.rst` alone—RTD leaves that sidebar empty until the page is opened. Keep `collapse_navigation: False` and `titles_only: True` in `conf.py`. Omit `binder_impl` from the sidebar.
+API nav: grouped `toctree`s on `docs/index.rst` (Core DI, Bindings, Discovery, Test doubles, Integrations). Keep `collapse_navigation: False` and `titles_only: True`. Omit `binder_impl`. New public modules need `docs/pyiv/pyiv.<name>.rst` and a toctree entry.
 
-New public modules need a `docs/pyiv/pyiv.<name>.rst` automodule page **and** a toctree entry on `index.rst`.
+Production is https://rl337.org/pyiv/ from `main`. PR previews are `/branch/<branch>/` only.
 
-Production site is https://rl337.org/pyiv/ from `main`. PR previews go to `/branch/<branch>/`; they must not deploy over the site root.
+If a changelog page exists, link it from the site and from `project.urls`.

--- a/.cursor/skills/maintain-docs/SKILL.md
+++ b/.cursor/skills/maintain-docs/SKILL.md
@@ -1,29 +1,38 @@
 ---
 name: maintain-docs
-description: Keep pyiv's README, Sphinx site, and module doctests aligned. Use when editing pyiv public APIs, docs/, README.md, Sphinx pages, Key Features, or install instructions; when adding modules to the API nav; or when the user mentions the website, documentation, or doctests.
+description: Keep pyiv's PyPI listing, Sphinx site, and release notes in sync. Use when editing README.md, docs/, pyproject.toml metadata or URLs, CHANGELOG, GitHub releases, install instructions, Key Features, public APIs, or doctests; when adding modules to the API nav; or when the user mentions the website, PyPI, documentation, or changelog.
 ---
 
 # Maintain pyiv docs
 
-## Split
+Three public surfaces must agree. Docstrings feed the site; they are not a fourth landing page.
 
-| Surface | Job |
-| --- | --- |
-| `README.md` | GitHub landing: one-paragraph what/why, honest install, short quick start, link to https://rl337.org/pyiv/. Not a second API manual. |
-| `docs/` (Sphinx) | Product docs: features, install, examples, API from autodoc. |
-| `pyiv/**/*.py` docstrings | Source of truth for API pages. Examples are doctests and run in CI. |
+| Pillar | Files | Job |
+| --- | --- | --- |
+| PyPI listing | `README.md`, `[project]` in `pyproject.toml` | README is GitHub **and** Warehouse long_description. Metadata (author, URLs, description) is the sidebar. Not a second API manual. |
+| Website | `docs/`, `pyiv/**/*.py` docstrings | Product manual at https://rl337.org/pyiv/. Features, install, guide, autodoc. Production is `main` only; PRs go to `/branch/<name>/`. |
+| Release notes | `CHANGELOG.md` (when present), GitHub Releases, `RELEASE.md`, `.github/workflows/release.yml` | Why this version shipped. Same install command as README. Not a squash-commit dump that tells people to `pip install` a version that is not on PyPI. |
 
-Do not claim `pip install pyiv` or link PyPI until the package is published. Install copy is `pip install git+https://github.com/rl337/pyiv.git`. Do not mention Poetry.
+## Install story (must match all three)
+
+Until a production PyPI upload exists:
+
+- Install: `pip install git+https://github.com/rl337/pyiv.git`
+- Do not write `pip install pyiv`, do not link https://pypi.org/project/pyiv/, do not mention Poetry.
+- First public version is **0.3.0**, not a 0.2.x tag.
+
+After that upload, flip README, `docs/index.rst`, changelog/release templates, and `project.urls` together in the same change.
+
+Canonical URLs (also `[project.urls]`): Homepage/Repository `https://github.com/rl337/pyiv`, Documentation `https://rl337.org/pyiv/`. No `yourusername` placeholders.
 
 ## After a public API change
 
-1. Update the module docstring with a **runnable** doctest (self-contained stubs, no network, no real sleeps, no writing cwd files).
-2. If you added a public module, add `docs/pyiv/pyiv.<module>.rst` and list it in the matching toctree on `docs/index.rst` (not only `modules.rst`). Do not put `binder_impl` in the sidebar.
-3. Keep homepage **Key Features** as: type injection, scopes, keys/binder, reflection, test doubles, zero deps. Do not promote Factory as a headline feature.
-4. Run `pytest --doctest-modules pyiv` and `sphinx-build -b html docs docs/_build/html`.
-
-Production docs are https://rl337.org/pyiv/ (main only). PR previews publish to `https://rl337.org/pyiv/branch/<branch>/`.
+1. Runnable module doctest (self-contained; no network, real sleeps, or cwd writes).
+2. New public module: `docs/pyiv/pyiv.<module>.rst` **and** the matching toctree on `docs/index.rst`. Omit `binder_impl`.
+3. Homepage Key Features stay: type injection, scopes, keys/binder, reflection, test doubles, zero deps. Not Factory-first.
+4. If the change is user-visible, add a changelog bullet the release notes can use.
+5. `pytest --doctest-modules pyiv` and `sphinx-build -b html docs docs/_build/html`.
 
 ## Sidebar UX
 
-RTD only shows nested toctrees from **the current page**. Put grouped `.. toctree::` directives on `docs/index.rst` so Core DI / Bindings / Discovery / Test doubles / Integrations are populated on first visit. Keep `collapse_navigation: False` and `titles_only: True` in `docs/conf.py` so the homepage sidebar lists module pages without dumping every method.
+RTD only expands nested toctrees from the current page. Grouped `.. toctree::` directives live on `docs/index.rst`. Keep `collapse_navigation: False` and `titles_only: True` in `docs/conf.py`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,17 +11,19 @@ third-party dependencies.
 
 ## Documentation
 
-**README.md** is the GitHub landing page: what pyiv is, how to install, a short
-quick start, and a link to the site. Keep it short. Do not duplicate the API
-manual. Do not claim `pip install pyiv` until the package is on PyPI.
+Three surfaces must stay in sync (see `.cursor/skills/maintain-docs/SKILL.md`):
 
-**docs/** (Sphinx, https://rl337.org/pyiv/) is the product manual: features,
-install, quick start, and API pages generated from `pyiv` docstrings. Homepage
-Key Features should match the product (injection, scopes, keys/binder,
+- **README.md + `pyproject.toml`**: GitHub and PyPI listing (short; honest install; real author/URLs)
+- **docs/** (https://rl337.org/pyiv/): product manual; API from `pyiv` docstrings
+- **Changelog / GitHub Releases**: why the version shipped; same install command as README
+
+Do not claim `pip install pyiv` until the package is on PyPI. First public version is 0.3.0.
+
+Homepage Key Features should match the product (injection, scopes, keys/binder,
 reflection, test doubles, zero deps)—not factory-first copy.
 
 When you change a public module, update its docstring (doctest-backed) so the
-website stays accurate. See `.cursor/skills/maintain-docs/SKILL.md`.
+website stays accurate.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- Expand `maintain-docs` so PyPI metadata (`pyproject.toml` + README), the Sphinx site, and GitHub release copy share one install story and canonical URLs.
- Add `.cursor/rules/packaging-docs.mdc` for metadata/release files; point `AGENTS.md` at the three pillars.
- Until 0.3.0 is on PyPI, agents must not write `pip install pyiv` or `yourusername` placeholders.

## Test plan
- [ ] Documentation workflow on this PR comments a `/branch/docs/three-pillars-sync/` preview (homepage should be unchanged).
- [ ] After merge, https://rl337.org/pyiv/ is unchanged (no user-facing docs in this PR).
- [ ] Spot-check that `maintain-docs` / `packaging-docs` fire when editing README, `pyproject.toml`, or `RELEASE.md`.
