### PR TITLE
Fix package metadata and stop claiming a PyPI install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,8 +207,9 @@ jobs:
             ${{ github.event.workflow_run.head_commit.message || 'Automated release' }}
             
             ### Installation
+            pyiv is not on PyPI yet. Install this tag from git:
             ```bash
-            pip install pyiv==${{ steps.new_version.outputs.new_version }}
+            pip install git+https://github.com/rl337/pyiv.git@v${{ steps.new_version.outputs.new_version }}
             ```
             
             ### Distribution Files

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 pyiv contributors
+Copyright (c) 2024-2026 Richard Lee
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,9 +44,10 @@ Each release includes:
 - **Source Distribution** (`.tar.gz`): Contains the source code
 - **Wheel Distribution** (`.whl`): Pre-built binary distribution
 
-Both are automatically attached to the GitHub Release and can be installed via:
+Both are attached to the GitHub Release. pyiv is not on PyPI yet; install a tagged revision from git:
+
 ```bash
-pip install pyiv==<version>
+pip install git+https://github.com/rl337/pyiv.git@v<version>
 ```
 
 ## Release Artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "hatchling.build"
 [project]
 name = "pyiv"
 version = "0.2.21"
-description = "A lightweight dependency injection library for Python"
+description = "Guice-style dependency injection for Python, with scopes, qualified keys, and test doubles"
 readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 authors = [
-    {name = "Your Name", email = "your.email@example.com"},
+    {name = "Richard Lee", email = "rlee@tokyo3.com"},
 ]
 keywords = ["dependency-injection", "di", "injector", "ioc"]
 classifiers = [
@@ -43,10 +43,10 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/pyiv"
-Documentation = "https://github.com/yourusername/pyiv#readme"
-Repository = "https://github.com/yourusername/pyiv"
-Issues = "https://github.com/yourusername/pyiv/issues"
+Homepage = "https://github.com/rl337/pyiv"
+Documentation = "https://rl337.org/pyiv/"
+Repository = "https://github.com/rl337/pyiv"
+Issues = "https://github.com/rl337/pyiv/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pyiv"]


### PR DESCRIPTION
## Summary
- Replace placeholder PyPI metadata (`Your Name`, `yourusername`) with Richard Lee, `rlee@tokyo3.com`, GitHub, and https://rl337.org/pyiv/. Description now matches the README one-liner. LICENSE copyright updated. No Changelog URL yet.
- GitHub Release notes and `RELEASE.md` now tell people to install a tagged git revision instead of `pip install pyiv==…`.

## Test plan
- [ ] Check `pyproject.toml` author, description, and `[project.urls]` look right for a future PyPI listing.
- [ ] Confirm LICENSE copyright is what you want.
- [ ] Skim a past GitHub Release body vs the new template in `.github/workflows/release.yml`.
- [ ] Leave README / docs install as git (already honest); this PR does not add `pip install pyiv`.
