### PR TITLE
Add a user guide and fix Sphinx-breaking docstring markup

### DIFF
--- a/.cursor/rules/website.mdc
+++ b/.cursor/rules/website.mdc
@@ -12,7 +12,7 @@ README is the GitHub **and** PyPI long description: what pyiv is, honest install
 
 Install must match README and release notes. Until PyPI exists: `pip install git+https://github.com/rl337/pyiv.git`. No `pip install pyiv`, no PyPI project link, no Poetry.
 
-API nav: grouped `toctree`s on `docs/index.rst` (Core DI, Bindings, Discovery, Test doubles, Integrations). Keep `collapse_navigation: False` and `titles_only: True`. Omit `binder_impl`. New public modules need `docs/pyiv/pyiv.<name>.rst` and a toctree entry.
+API nav: grouped `toctree`s on `docs/index.rst` (User guide, Core DI, Bindings, Discovery, Test doubles, Integrations). User guide pages live in `docs/guide/` with human titles. Keep `collapse_navigation: False` and `titles_only: True`. Omit `binder_impl`. New public modules need `docs/pyiv/pyiv.<name>.rst` and a toctree entry.
 
 Production is https://rl337.org/pyiv/ from `main`. PR previews are `/branch/<branch>/` only.
 

--- a/.cursor/skills/maintain-docs/SKILL.md
+++ b/.cursor/skills/maintain-docs/SKILL.md
@@ -35,4 +35,4 @@ Canonical URLs (also `[project.urls]`): Homepage/Repository `https://github.com/
 
 ## Sidebar UX
 
-RTD only expands nested toctrees from the current page. Grouped `.. toctree::` directives live on `docs/index.rst`. Keep `collapse_navigation: False` and `titles_only: True` in `docs/conf.py`.
+RTD only expands nested toctrees from the current page. Grouped `.. toctree::` directives live on `docs/index.rst` (User guide in `docs/guide/`, then API groups). Keep `collapse_navigation: False` and `titles_only: True` in `docs/conf.py`.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ injector = get_injector(MyConfig)
 db = injector.inject(Database)  # PostgreSQL
 ```
 
-The website covers Binder, Keys, scopes, reflection, multibindings, and the
-Clock / Filesystem / Console / DateTimeService test doubles.
+The [user guide](https://rl337.org/pyiv/) covers Binder, Keys, scopes,
+and the Clock / Filesystem / Console / DateTimeService test doubles.
 
 ## Development
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -13,6 +13,34 @@
     margin: 20px 0;
 }
 
+/* Homepage version badge (|release| cannot be substituted inside raw HTML) */
+.rst-content .hero-meta {
+    margin: 12px 0 20px 0;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.rst-content .hero-meta p {
+    margin: 0;
+}
+
+.rst-content .version-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    background: var(--pyiv-blue);
+    color: #fff;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 500;
+}
+
+.rst-content .version-badge p {
+    margin: 0;
+    color: #fff;
+}
+
 /* Improve code block styling */
 .rst-content .highlight {
     background: #f5f5f5;

--- a/docs/guide/binding.rst
+++ b/docs/guide/binding.rst
@@ -1,0 +1,71 @@
+Binding
+=======
+
+Register an abstract type once. The injector builds constructor arguments from
+annotations.
+
+``Config.register``
+-------------------
+
+The direct API. ``concrete`` can be a class or a zero-argument factory:
+
+.. code-block:: python
+
+   from pyiv import Config, get_injector
+
+   class Database:
+       pass
+
+   class PostgreSQL(Database):
+       pass
+
+   class Logger:
+       pass
+
+   class FileLogger(Logger):
+       pass
+
+   class MyConfig(Config):
+       def configure(self):
+           self.register(Database, PostgreSQL)
+           self.register(Logger, FileLogger, singleton=True)
+
+   injector = get_injector(MyConfig)
+   injector.inject(Database)  # PostgreSQL
+
+``singleton=True`` is a per-injector singleton. See :doc:`scopes` for
+``Scope`` and process-wide singletons.
+
+Binder
+------
+
+``get_binder()`` is the same registrations with a fluent chain. Use it when
+you want ``.to(...)``, ``.to_instance(...)``, or ``.in_scope(...)`` in one
+expression:
+
+.. code-block:: python
+
+   from pyiv import Config
+   from pyiv.scope import SingletonScope
+
+   class Cache:
+       pass
+
+   class MyConfig(Config):
+       def configure(self):
+           binder = self.get_binder()
+           binder.bind(Database).to(PostgreSQL)
+           binder.bind(Logger).to(FileLogger).in_scope(SingletonScope())
+           binder.bind_instance(Cache, Cache())
+
+``register`` and Binder write the same config. Pick one style per project;
+mixing them in one ``configure()`` is fine.
+
+Unregistered concrete types
+---------------------------
+
+If you ``inject()`` a **concrete** class that was never registered, the
+injector still constructs it and fills its annotated parameters. Interfaces
+and ABCs must be bound (or marked optional — see :doc:`keys`).
+
+See also :doc:`/pyiv/pyiv.config` and :doc:`/pyiv/pyiv.binder`.

--- a/docs/guide/keys.rst
+++ b/docs/guide/keys.rst
@@ -1,0 +1,105 @@
+Keys and collections
+====================
+
+Several implementations of one type need a qualifier. Several implementations
+**as a set or list** use a multibinder.
+
+Qualified keys
+--------------
+
+``Key(Type, Named("..."))`` is the Guice-style named binding:
+
+.. code-block:: python
+
+   from pyiv import Config, get_injector
+   from pyiv.key import Key, Named
+
+   class Database:
+       def __init__(self, name: str):
+           self.name = name
+
+   class PostgreSQL(Database):
+       def __init__(self):
+           super().__init__("postgresql")
+
+   class MySQL(Database):
+       def __init__(self):
+           super().__init__("mysql")
+
+   class MyConfig(Config):
+       def configure(self):
+           self.register_key(Key(Database, Named("primary")), PostgreSQL)
+           self.register_key(Key(Database, Named("replica")), MySQL)
+
+   injector = get_injector(MyConfig)
+   injector.inject(Key(Database, Named("primary")))  # PostgreSQL
+   injector.inject(Key(Database, Named("replica")))  # MySQL
+
+Binder equivalent: ``binder.bind_key(Key(Database, Named("primary"))).to(...)``.
+
+Multibinder
+-----------
+
+Register many implementations and inject ``Set[T]`` or ``List[T]``. Inject
+the collection through a **host class constructor**, not
+``injector.inject(Set[T])``:
+
+.. code-block:: python
+
+   from typing import Set
+
+   from pyiv import Config, get_injector
+
+   class EventHandler:
+       pass
+
+   class EmailHandler(EventHandler):
+       pass
+
+   class SMSHandler(EventHandler):
+       pass
+
+   class HandlerHost:
+       def __init__(self, handlers: Set[EventHandler]):
+           self.handlers = handlers
+
+   class MyConfig(Config):
+       def configure(self):
+           mb = self.multibinder(EventHandler, as_set=True)
+           mb.add(EmailHandler)
+           mb.add(SMSHandler)
+
+   host = get_injector(MyConfig).inject(HandlerHost)
+   # host.handlers is EmailHandler and SMSHandler
+
+``as_set=False`` binds ``List[T]`` and preserves add order.
+
+Optional dependencies
+---------------------
+
+``Optional[T]`` injects the binding or ``None``. Use an **ABC** (or another
+type the injector cannot construct) for ``T``. A concrete class with no
+binding is still built:
+
+.. code-block:: python
+
+   from abc import ABC
+   from typing import Optional
+
+   from pyiv import Config, get_injector
+
+   class Cache(ABC):
+       pass
+
+   class Service:
+       def __init__(self, cache: Optional[Cache] = None):
+           self.cache = cache
+
+   class NoCacheConfig(Config):
+       def configure(self):
+           pass  # Cache not registered
+
+   get_injector(NoCacheConfig).inject(Service).cache is None  # True
+
+See also :doc:`/pyiv/pyiv.key`, :doc:`/pyiv/pyiv.multibinder`, and
+:doc:`/pyiv/pyiv.optional`.

--- a/docs/guide/scopes.rst
+++ b/docs/guide/scopes.rst
@@ -1,0 +1,62 @@
+Scopes
+======
+
+A scope decides whether ``inject()`` returns a new object or a cached one.
+
+Default (no scope)
+------------------
+
+Each ``inject()`` call constructs a new instance:
+
+.. code-block:: python
+
+   from pyiv import Config, get_injector
+
+   class Logger:
+       pass
+
+   class FileLogger(Logger):
+       pass
+
+   class MyConfig(Config):
+       def configure(self):
+           self.register(Logger, FileLogger)
+
+   injector = get_injector(MyConfig)
+   injector.inject(Logger) is injector.inject(Logger)  # False
+
+Per-injector singleton
+----------------------
+
+One instance **per** ``Injector``. Separate ``get_injector()`` calls do not
+share it:
+
+.. code-block:: python
+
+   from pyiv import Config, get_injector
+   from pyiv.scope import SingletonScope
+
+   class MyConfig(Config):
+       def configure(self):
+           self.register(Logger, FileLogger, singleton=True)
+           # equivalent: scope=SingletonScope()
+
+   a = get_injector(MyConfig)
+   b = get_injector(MyConfig)
+   a.inject(Logger) is a.inject(Logger)  # True
+   a.inject(Logger) is b.inject(Logger)  # False
+
+Process-wide singleton
+----------------------
+
+``GlobalSingletonScope`` (or ``SingletonType.GLOBAL_SINGLETON``) caches one
+instance for the whole process. Use it for things like a process-wide cache;
+avoid it in tests unless you reset that cache.
+
+Custom scopes
+-------------
+
+Implement :class:`~pyiv.scope.Scope` when you need request, thread, or
+session lifetime. Built-in scopes are enough for most apps.
+
+See also :doc:`/pyiv/pyiv.scope` and :doc:`/pyiv/pyiv.singleton`.

--- a/docs/guide/testing.rst
+++ b/docs/guide/testing.rst
@@ -1,0 +1,57 @@
+Testing with doubles
+====================
+
+Bind production types in one config and in-memory doubles in another. Tests
+should not mock ``time``, the filesystem, or ``sys.stdout``.
+
+.. code-block:: python
+
+   from pyiv import Config, get_injector
+   from pyiv.clock import Clock, RealClock, SyntheticClock
+   from pyiv.console import Console, MemoryConsole, RealConsole
+   from pyiv.datetime_service import DateTimeService, MockDateTimeService, PythonDateTimeService
+   from pyiv.filesystem import Filesystem, MemoryFilesystem, RealFilesystem
+
+   class ProdConfig(Config):
+       def configure(self):
+           self.register(Clock, RealClock)
+           self.register(Filesystem, RealFilesystem)
+           self.register(Console, RealConsole)
+           self.register(DateTimeService, PythonDateTimeService)
+
+   class TestConfig(Config):
+       def configure(self):
+           self.register(
+               Clock,
+               lambda: SyntheticClock(start_time=100.0),
+               singleton=True,
+           )
+           self.register(Filesystem, MemoryFilesystem)
+           self.register(Console, MemoryConsole)
+           self.register(DateTimeService, MockDateTimeService)
+
+   injector = get_injector(TestConfig)
+   clock = injector.inject(Clock)
+   clock.advance(5.0)
+   clock.time()  # 105.0
+
+   fs = injector.inject(Filesystem)
+   fs.write_text("test.txt", "content")  # in memory, not the repo
+
+   console = injector.inject(Console)
+   print("hello", file=console)
+   console.getvalue()  # contains "hello"
+
+What to swap
+------------
+
+* **Clock / SyntheticClock** — freeze and advance time; no real sleeps.
+* **Filesystem / MemoryFilesystem** — read and write paths without touching disk.
+* **Console / MemoryConsole** — capture ``print(..., file=console)``.
+* **DateTimeService / MockDateTimeService** — fixed UTC timestamps.
+
+Keep the rest of the object graph on real classes. Only replace the edges that
+talk to the world.
+
+See also :doc:`/pyiv/pyiv.clock`, :doc:`/pyiv/pyiv.filesystem`,
+:doc:`/pyiv/pyiv.console`, and :doc:`/pyiv/pyiv.datetime_service`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,12 +7,15 @@ A Guice-style dependency injection library for Python. Register bindings,
 inject by type, and swap production implementations for test doubles without
 mocking the world.
 
-.. raw:: html
+.. container:: hero-meta
 
-   <p style="margin: 12px 0 20px 0;">
-   <span style="display: inline-block; padding: 4px 8px; background: #0066cc; color: white; border-radius: 4px; font-size: 0.85em; font-weight: 500; margin-right: 10px;">v|release|</span>
+   .. container:: version-badge
+
+      |release|
+
    Zero runtime dependencies. Python 3.8+.
-   </p>
+
+.. raw:: html
 
    <div style="margin: 20px 0; padding: 15px; background: #e8f4f8; border-left: 4px solid #0066cc; border-radius: 4px;">
    <strong>Quick Links:</strong>
@@ -91,35 +94,20 @@ Quick Start
    db = injector.inject(Database)       # PostgreSQL
    logger = injector.inject(Logger)     # shared per injector
 
-Fluent Binder and qualified keys are documented on :doc:`pyiv/pyiv.binder`
-and :doc:`pyiv/pyiv.key`.
+User Guide
+----------
 
-Testing with Abstractions
--------------------------
+Binder vs ``register``, scopes, qualified keys, and swapping Clock /
+Filesystem / Console / DateTimeService in tests:
 
-Swap production types for in-memory doubles in a test config:
+.. toctree::
+   :maxdepth: 1
+   :caption: User guide
 
-.. code-block:: python
-
-   from pyiv import Config, get_injector
-   from pyiv.clock import Clock, RealClock, SyntheticClock
-   from pyiv.filesystem import Filesystem, MemoryFilesystem, RealFilesystem
-
-   class ProdConfig(Config):
-       def configure(self):
-           self.register(Clock, RealClock)
-           self.register(Filesystem, RealFilesystem)
-
-   class TestConfig(Config):
-       def configure(self):
-           self.register(Clock, lambda: SyntheticClock(start_time=100.0), singleton=True)
-           self.register(Filesystem, MemoryFilesystem)
-
-   injector = get_injector(TestConfig)
-   clock = injector.inject(Clock)
-   clock.advance(5.0)
-   fs = injector.inject(Filesystem)
-   fs.write_text("test.txt", "content")
+   Binding <guide/binding>
+   Scopes <guide/scopes>
+   Keys and collections <guide/keys>
+   Testing with doubles <guide/testing>
 
 API Reference
 -------------

--- a/pyiv/__init__.py
+++ b/pyiv/__init__.py
@@ -1,45 +1,19 @@
-"""pyiv - A lightweight dependency injection library for Python.
+"""Guice-style dependency injection for Python.
 
-PyIV (Python Injection and Validation) is a lightweight, type-aware dependency
-injection library designed for Python applications. It provides a simple yet
-powerful way to manage dependencies, improve testability, and reduce coupling.
+pyiv provides type-based constructor injection, scopes, qualified keys, and
+built-in test doubles. Runtime has zero third-party dependencies. Python 3.8+.
 
 Key Features:
-    - Type-based dependency resolution using annotations
-    - Provider interface for lazy initialization and injector access
-    - Scope management for extensible lifecycle control
-    - Qualified bindings with type-safe keys
-    - Fluent configuration API with Binder
-    - Field/method injection with MembersInjector
-    - Optional dependencies with Optional[T] support
-    - Multibindings for multiple implementations
-    - Singleton lifecycle management (per-injector or global)
-    - Factory pattern support for complex object creation
-    - Built-in abstractions for common dependencies (Clock, Filesystem, etc.)
-    - Zero external dependencies (pure Python)
 
-Architecture:
-    The library is organized into modules:
-    - config: Configuration base class for registering dependencies
-    - injector: Core dependency injection engine
-    - provider: Provider interface for lazy initialization
-    - scope: Scope interface for lifecycle management
-    - key: Key/Qualifier for type-safe qualified bindings
-    - binder: Binder interface for fluent configuration
-    - members: MembersInjector for field/method injection
-    - optional: Optional dependency support
-    - multibinder: Multibinder for multiple implementations
-    - chain: Chain of responsibility pattern for extensible handlers
-    - serde: Serialization/deserialization implementations
-    - network: Network client abstractions (HTTP, HTTPS, etc.)
-    - singleton: Singleton lifecycle management
-    - factory: Factory pattern support
-    - clock: Time abstraction for testing
-    - filesystem: File I/O abstraction for testing
-    - console: Console output abstraction for testing
-    - datetime_service: DateTime abstraction for testing
+- Type-based constructor injection from annotations
+- Scopes (per-injector and process-wide singletons, plus custom Scope)
+- Qualified keys and a fluent Binder API
+- Reflection to discover implementations in a package
+- Test doubles for Clock, Filesystem, Console, and DateTimeService
+- Zero runtime dependencies
 
 Quick Start:
+
     >>> from pyiv import Config, get_injector
     >>> class Database:
     ...     pass
@@ -51,8 +25,6 @@ Quick Start:
     >>> injector = get_injector(MyConfig)
     >>> isinstance(injector.inject(Database), PostgreSQL)
     True
-
-For more information, see the individual module documentation.
 """
 
 from pyiv.binder import Binder, BindingBuilder

--- a/pyiv/binder.py
+++ b/pyiv/binder.py
@@ -8,13 +8,15 @@ configuration.
 **What Problem Does This Solve?**
 
 Binders solve the configuration API design problem:
+
 - **Fluent API**: Method chaining for readable, expressive configuration
 - **Separation of Concerns**: Configuration API separated from implementation
 - **Testability**: Mock binders for testing configuration logic
 - **Programmatic Configuration**: Build configurations dynamically
-- **Better Readability**: `binder.bind(X).to(Y).in_scope(Z)` is clearer than nested calls
+- **Better Readability**: ``binder.bind(X).to(Y).in_scope(Z)`` is clearer than nested calls
 
 **Real-World Use Cases:**
+
 - **Dynamic Configuration**: Build configurations based on environment variables
 - **Configuration Testing**: Mock binders to test configuration logic
 - **Modular Configuration**: Compose configurations from multiple sources
@@ -154,7 +156,8 @@ class Binder(Protocol):
     They separate the configuration API from the implementation, making
     Config more testable and enabling programmatic configuration.
 
-    Example:
+    Example::
+
         class MyBinder(Binder):
             def bind(self, abstract):
                 return BindingBuilder(...)

--- a/pyiv/command.py
+++ b/pyiv/command.py
@@ -314,7 +314,7 @@ class CommandRunner:
 
         Args:
             package_path: Python package path (e.g., "agenticness.commands")
-            pattern: Optional name pattern for filtering (e.g., "*Command")
+            pattern: Optional name pattern for filtering (e.g. ``*Command``)
             recursive: Whether to scan submodules recursively
 
         Returns:

--- a/pyiv/console.py
+++ b/pyiv/console.py
@@ -8,6 +8,7 @@ to stdout.
 **What Problem Does This Solve?**
 
 Console output solves the "print() testing" problem:
+
 - **Testability**: Capture print() output in tests without mocking sys.stdout
 - **Flexibility**: Redirect console output to files, memory, or custom handlers
 - **Dependency Injection**: Make console output injectable like other dependencies
@@ -15,6 +16,7 @@ Console output solves the "print() testing" problem:
 - **Test Isolation**: Each test can have its own console instance
 
 **Real-World Use Cases:**
+
 - **CLI Applications**: Capture command output for testing
 - **Interactive Programs**: Test user prompts and responses
 - **Progress Indicators**: Test progress bars and status messages

--- a/pyiv/factory.py
+++ b/pyiv/factory.py
@@ -44,7 +44,8 @@ class Factory(Protocol, Generic[T]):
     dependencies that need to be injected. This protocol defines the
     interface that factories should implement.
 
-    Example:
+    Example::
+
         class DatabaseFactory(Factory[Database]):
             def create(self, connection_string: str) -> Database:
                 return PostgreSQL(connection_string)
@@ -69,7 +70,8 @@ class BaseFactory(ABC, Generic[T]):
     Provides a concrete base class for factories that need to be
     instantiated. Subclasses should implement the `create()` method.
 
-    Example:
+    Example::
+
         class UserFactory(BaseFactory[User]):
             def __init__(self, db: Database):
                 self._db = db
@@ -99,16 +101,15 @@ class SimpleFactory(Generic[T]):
     without needing to define a full class.
 
     Example:
-        # Factory from a function
-        def create_user(name: str) -> User:
-            return User(name=name)
-
-        factory = SimpleFactory(create_user)
-        user = factory.create("Alice")
-
-        # Factory from a class constructor
-        factory = SimpleFactory(PostgreSQL)
-        db = factory.create(connection_string="postgresql://...")
+        >>> class User:
+        ...     def __init__(self, name: str):
+        ...         self.name = name
+        >>> def create_user(name: str) -> User:
+        ...     return User(name=name)
+        >>> from pyiv.factory import SimpleFactory
+        >>> factory = SimpleFactory(create_user)
+        >>> factory.create("Alice").name
+        'Alice'
     """
 
     def __init__(self, callable_factory: Callable[..., T]):

--- a/pyiv/injector.py
+++ b/pyiv/injector.py
@@ -10,10 +10,11 @@ Architecture:
 
 The injector uses type annotations and Config registrations to automatically
 resolve dependencies. It supports:
-    - Constructor injection via type annotations
-    - Singleton lifecycle management
-    - Factory functions for complex object creation
-    - Circular dependency detection
+
+- Constructor injection via type annotations
+- Singleton lifecycle management
+- Factory functions for complex object creation
+- Circular dependency detection
 
 Usage:
     Create a Config subclass, register dependencies, then create an injector:
@@ -684,18 +685,16 @@ def get_injector(config: Union[Type[Config], Config]) -> Injector:
         An Injector instance configured with the given config
 
     Example:
-        # Using a Config class
-        class MyConfig(Config):
-            def configure(self):
-                self.register(Database, PostgreSQL)
-
-        injector = get_injector(MyConfig)
-        db = injector.inject(Database)
-
-        # Using a Config instance (useful for test configs with parameters)
-        test_config = MyTestConfig(mock_db=my_mock)
-        injector = get_injector(test_config)
-        db = injector.inject(Database)
+        >>> from pyiv import Config, get_injector
+        >>> class Database:
+        ...     pass
+        >>> class PostgreSQL(Database):
+        ...     pass
+        >>> class MyConfig(Config):
+        ...     def configure(self):
+        ...         self.register(Database, PostgreSQL)
+        >>> isinstance(get_injector(MyConfig).inject(Database), PostgreSQL)
+        True
     """
     if isinstance(config, Config):
         # Already an instance, use it directly

--- a/pyiv/key.py
+++ b/pyiv/key.py
@@ -7,13 +7,14 @@ to be distinguished using qualifiers (like @Named in Guice).
 **What Problem Does This Solve?**
 
 Keys solve the "multiple implementations" problem:
-- **Type Safety**: Distinguish between multiple implementations of the same type
-  without using string-based names (which are error-prone)
+
+- **Type Safety**: Distinguish implementations of one type without string names
 - **IDE Support**: Better autocomplete and type checking than string qualifiers
 - **Compile-Time Safety**: Catch binding errors at configuration time, not runtime
 - **Clear Intent**: Makes it explicit which implementation is being used
 
 **Real-World Use Cases:**
+
 - **Multiple Database Connections**: Primary vs replica databases
 - **Different Logger Implementations**: File logger vs console logger vs remote logger
 - **Environment-Specific Configs**: Development vs production vs test configurations

--- a/pyiv/members.py
+++ b/pyiv/members.py
@@ -8,14 +8,15 @@ is not possible.
 **What Problem Does This Solve?**
 
 MembersInjector solves the "framework-managed objects" problem:
-- **Framework Integration**: Inject into objects created by frameworks (Django models,
-  Flask request objects, etc.) where you can't control the constructor
-- **Legacy Code**: Migrate existing code to DI without refactoring all constructors
-- **Third-Party Objects**: Inject dependencies into objects from libraries you don't control
-- **Data Classes**: Support field injection for dataclasses and attrs classes
+
+- **Framework Integration**: Inject into objects you did not construct
+- **Legacy Code**: Migrate existing code to DI without refactoring constructors
+- **Third-Party Objects**: Inject dependencies into objects you do not control
+- **Data Classes**: Field injection for dataclasses and attrs classes
 - **Flexibility**: Use field injection when constructor injection is impractical
 
 **Real-World Use Cases:**
+
 - **Django Models**: Inject services into Django model instances
 - **Flask Request Context**: Inject dependencies into Flask request objects
 - **Legacy Codebase**: Gradually migrate to DI without breaking existing code

--- a/pyiv/multibinder.py
+++ b/pyiv/multibinder.py
@@ -8,6 +8,7 @@ with multiple strategies.
 **What Problem Does This Solve?**
 
 Multibinders solve the "multiple implementations" problem:
+
 - **Plugin Systems**: Register and inject multiple plugins of the same type
 - **Event Handlers**: Multiple event handlers that all need to be notified
 - **Chain of Responsibility**: Multiple handlers that process requests in sequence
@@ -15,6 +16,7 @@ Multibinders solve the "multiple implementations" problem:
 - **Validation Chains**: Multiple validators that all need to run
 
 **Real-World Use Cases:**
+
 - **Event System**: Multiple event listeners for the same event type
 - **Validation Pipeline**: Multiple validators that all need to run
 - **Middleware Stack**: Multiple middleware components in a web framework

--- a/pyiv/optional.py
+++ b/pyiv/optional.py
@@ -7,6 +7,7 @@ dependency if available, or None if not registered.
 **What Problem Does This Solve?**
 
 Optional dependencies solve the "graceful degradation" problem:
+
 - **Feature Flags**: Support optional features that may or may not be available
 - **Plugin Systems**: Optional plugins that enhance functionality if present
 - **Environment-Specific Dependencies**: Different dependencies in dev vs production
@@ -14,6 +15,7 @@ Optional dependencies solve the "graceful degradation" problem:
 - **Type Safety**: Use Optional[T] instead of manual None checks
 
 **Real-World Use Cases:**
+
 - **Optional Caching**: Cache service that may or may not be available
 - **Optional Monitoring**: Metrics/analytics that are optional in development
 - **Optional Plugins**: Third-party integrations that may not be installed

--- a/pyiv/provider.py
+++ b/pyiv/provider.py
@@ -7,12 +7,14 @@ lazy initialization, injector access, and deferred creation.
 **What Problem Does This Solve?**
 
 Providers solve several common DI scenarios:
+
 - **Lazy Initialization**: Create instances only when needed, not at injection time
 - **Multiple Instances**: Get multiple instances of the same type (unlike singletons)
 - **Injector Access**: Access the injector during instance creation for complex logic
 - **Deferred Creation**: Delay expensive object creation until actually needed
 
 **Real-World Use Cases:**
+
 - Database connections that should be created on-demand, not at startup
 - Services that need to create multiple instances (e.g., user sessions)
 - Objects that require the injector to resolve their own dependencies dynamically

--- a/pyiv/reflection.py
+++ b/pyiv/reflection.py
@@ -22,15 +22,15 @@ class ReflectionConfig(Config):
     to scan, and all implementations of an interface will be automatically discovered
     and registered.
 
-    Example:
+    Example::
+
         class MyConfig(ReflectionConfig):
             def configure(self):
-                # Register module for handler discovery
                 self.register_module(
                     Handler,
                     "my_service.handlers",
                     pattern="*Handler",
-                    singleton_type=SingletonType.SINGLETON
+                    singleton_type=SingletonType.SINGLETON,
                 )
     """
 
@@ -52,8 +52,9 @@ class ReflectionConfig(Config):
         Args:
             interface: The abstract class or interface to find implementations of
             package_path: Python package path (e.g., "my_service.mcp.handlers")
-            pattern: Optional name pattern for filtering (e.g., "*Handler", "handle_*")
-                     Uses fnmatch syntax. If None, all implementations are discovered.
+            pattern: Optional name pattern for filtering (e.g. ``*Handler``,
+                ``handle_*``). Uses fnmatch syntax. If None, all implementations
+                are discovered.
             recursive: Whether to scan submodules recursively (default: True)
             singleton_type: How to handle instances (default: SINGLETON for per-injector reuse)
 
@@ -61,19 +62,18 @@ class ReflectionConfig(Config):
             TypeError: If interface is not a type
             ImportError: If the package cannot be imported
 
-        Example:
-            # Discover all classes ending in "Handler" that implement Handler
+        Example::
+
             self.register_module(
                 Handler,
                 "my_service.handlers",
-                pattern="*Handler"
+                pattern="*Handler",
             )
 
-            # Discover all implementations recursively
             self.register_module(
                 Service,
                 "my_service.services",
-                recursive=True
+                recursive=True,
             )
         """
         if not isinstance(interface, type):

--- a/pyiv/scope.py
+++ b/pyiv/scope.py
@@ -8,14 +8,15 @@ custom scopes like request-scoped, thread-scoped, session-scoped, etc.
 **What Problem Does This Solve?**
 
 Scopes solve the lifecycle management problem in DI:
-- **Singleton Pattern Generalization**: Beyond simple singletons, support request-scoped,
-  thread-scoped, session-scoped, and custom lifecycles
+
+- **Singleton Pattern Generalization**: Request, thread, session, and custom lifecycles
 - **Resource Management**: Control when expensive objects are created and destroyed
-- **Test Isolation**: Different scopes for test vs production (e.g., per-injector vs global)
+- **Test Isolation**: Different scopes for test vs production (per-injector vs global)
 - **Thread Safety**: GlobalSingletonScope provides thread-safe singleton access
-- **Extensibility**: Create custom scopes for framework-specific needs (e.g., Flask request scope)
+- **Extensibility**: Custom scopes for framework-specific needs (e.g. request scope)
 
 **Real-World Use Cases:**
+
 - **Request-Scoped**: Database connections that live for the duration of an HTTP request
 - **Session-Scoped**: User session objects that persist across multiple requests
 - **Thread-Scoped**: Thread-local storage for multi-threaded applications
@@ -120,7 +121,8 @@ class Scope(Protocol):
     Scopes are more flexible than simple singletons - they can implement
     request-scoped, thread-scoped, session-scoped, or any custom lifecycle.
 
-    Example:
+    Example::
+
         class RequestScope(Scope):
             def __init__(self):
                 self._request_cache = {}

--- a/pyiv/serde/encodings.py
+++ b/pyiv/serde/encodings.py
@@ -2,12 +2,13 @@
 
 This module provides SerDe implementations for encoding formats available
 in Python's standard library:
-    - JSON: Standard JSON encoding
-    - Base64: Base64 encoding
-    - YAML: YAML encoding (if available)
-    - XML: XML encoding
-    - Pickle: Python pickle encoding (default/no-op fallback)
-    - NoOp: No-op encoding (pass-through)
+
+- JSON: Standard JSON encoding
+- Base64: Base64 encoding
+- YAML: YAML encoding (if available)
+- XML: XML encoding
+- Pickle: Python pickle encoding (default/no-op fallback)
+- NoOp: No-op encoding (pass-through)
 """
 
 import base64


### PR DESCRIPTION
## Summary
- Homepage version badge now uses Sphinx `|release|` (shows 0.2.23) instead of literal `v|release|` inside raw HTML.
- Add a short user guide: Binding, Scopes, Keys and collections, Testing with doubles. Sidebar caption is **User guide**.
- RST-safe module/class docstring lists and examples so autodoc pages no longer emit Unexpected indentation. Package docstring matches the homepage (not factory-first).

## Test plan
- [ ] Docs workflow comments a preview at https://rl337.org/pyiv/branch/docs/site-as-guide/
- [ ] Preview homepage shows a real version number, not `v|release|`
- [ ] Walk Binding / Scopes / Keys / Testing pages; inject-via-host-class and Optional-ABC notes read clearly
- [ ] Spot-check an API page that used to warn (`pyiv.key`, `pyiv.members`, `pyiv.reflection`)
- [ ] Production https://rl337.org/pyiv/ unchanged until merge
