### PR TITLE
Add a changelog and publish it on the docs site

### DIFF
--- a/.cursor/rules/packaging-docs.mdc
+++ b/.cursor/rules/packaging-docs.mdc
@@ -1,5 +1,5 @@
 ---
-description: PyPI metadata, install claims, and GitHub release copy must match README and the docs site.
+description: PyPI metadata, install claims, changelog format, and GitHub release copy must match README and the docs site.
 globs: pyproject.toml,RELEASE.md,CHANGELOG.md,LICENSE,.github/workflows/release.yml,.github/workflows/version-bump.yml
 alwaysApply: false
 ---
@@ -11,8 +11,17 @@ alwaysApply: false
 - Author and URLs must not be `Your Name` / `yourusername`.
 - `Documentation` = `https://rl337.org/pyiv/`
 - Homepage / Repository / Issues = `https://github.com/rl337/pyiv` (and `/issues`)
+- `Changelog` = `https://rl337.org/pyiv/changelog.html`
 - Description should match the README one-liner (Guice-style DI, not factory-first)
 
 Install commands in `RELEASE.md`, release workflow text, and GitHub Release bodies must match README. Until pyiv is on PyPI, that is the git URL, not `pip install pyiv` or `pip install pyiv==<version>`.
 
-Do not add a Changelog URL until `CHANGELOG.md` (or an equivalent site page) exists; then set it in `project.urls` and link it from the docs homepage.
+## Changelog
+
+`CHANGELOG.md` is the source of truth (GitHub, PyPI URL, Sphinx `docs/changelog.rst`). Keep a Changelog layout:
+
+- New user-facing work goes under `## Unreleased`. Do not invent `X.Y.Z` in a PR; versions are auto-bumped on `main`.
+- After that bump is on `main`, move Unreleased bullets to `## X.Y.Z - YYYY-MM-DD`.
+- User-facing only (Added / Changed / Deprecated / Removed / Fixed / Security). No “fix typo in comment,” no squash-commit dumps.
+- One set of bullets GitHub Releases can reuse. Same install command as README.
+- The docs homepage and `project.urls` Changelog must keep pointing at the site page.

--- a/.cursor/rules/website.mdc
+++ b/.cursor/rules/website.mdc
@@ -16,4 +16,4 @@ API nav: grouped `toctree`s on `docs/index.rst` (User guide, Core DI, Bindings, 
 
 Production is https://rl337.org/pyiv/ from `main`. PR previews are `/branch/<branch>/` only.
 
-If a changelog page exists, link it from the site and from `project.urls`.
+If a changelog page exists, link it from the site (homepage + Reference toctree) and from `project.urls`. `CHANGELOG.md` is the source of truth; `docs/changelog.rst` includes it.

--- a/.cursor/skills/maintain-docs/SKILL.md
+++ b/.cursor/skills/maintain-docs/SKILL.md
@@ -30,7 +30,7 @@ Canonical URLs (also `[project.urls]`): Homepage/Repository `https://github.com/
 1. Runnable module doctest (self-contained; no network, real sleeps, or cwd writes).
 2. New public module: `docs/pyiv/pyiv.<module>.rst` **and** the matching toctree on `docs/index.rst`. Omit `binder_impl`.
 3. Homepage Key Features stay: type injection, scopes, keys/binder, reflection, test doubles, zero deps. Not Factory-first.
-4. If the change is user-visible, add a changelog bullet the release notes can use.
+4. If the change is user-visible, add a bullet under `## Unreleased` in `CHANGELOG.md` (do not invent a version). GitHub Releases reuse those bullets.
 5. `pytest --doctest-modules pyiv` and `sphinx-build -b html docs docs/_build/html`.
 
 ## Sidebar UX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install project dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" || pip install -e .
+          pip install -e ".[dev,docs]" || pip install -e .
           # Pin versions for consistency across Python versions
           # black 25.x requires Python 3.9+, use 24.8.0 for Python 3.8 compatibility
           # isort 7.0.0 may not be available, use 5.13.2 for compatibility

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[docs]"
-          pip install sphinx sphinx-rtd-theme
 
       - name: Build documentation with Sphinx
         if: github.event.action != 'closed'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+User-facing changes to pyiv, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+order. The first public PyPI version will be **0.3.0**. Until then, install with:
+
+```bash
+pip install git+https://github.com/rl337/pyiv.git
+```
+
+## Unreleased
+
+### Added
+
+- This changelog, a [docs page](https://rl337.org/pyiv/changelog.html), and a
+  Changelog URL in package metadata.
+
+## 0.2.24 - 2026-08-29
+
+### Added
+
+- User guide: binding, scopes, keys and collections, testing with doubles.
+- Homepage version badge from the package version.
+
+### Fixed
+
+- Sphinx autodoc no longer breaks on Markdown-style lists in docstrings.
+- Package overview matches homepage features (injection, scopes, keys, test
+  doubles), not factory-first copy.
+
+## 0.2.22 - 2026-08-28
+
+### Changed
+
+- Package metadata: author Richard Lee, documentation
+  [https://rl337.org/pyiv/](https://rl337.org/pyiv/).
+- GitHub Releases and `RELEASE.md` install from git until PyPI exists.
+
+## 0.2.21 - 2026-08-28
+
+### Added
+
+- Product docs at [https://rl337.org/pyiv/](https://rl337.org/pyiv/) (git
+  install, grouped API nav).
+- Doctests in CI for examples in `pyiv` module docstrings.
+
+### Fixed
+
+- `register_key` keeps the implementation class.
+- `Multibinder.add` registers the binding.
+
+## 0.2.20 - 2026-08-28
+
+### Fixed
+
+- Singleton resolution no longer recurses into itself.
+- CI fails when pytest exits 2 (collection errors), not only on test failures.
+
+## Earlier 0.2.x
+
+Pre-PyPI history. Not every auto-bump is listed.
+
+### Added
+
+- Guice-style Provider, Scope, Key, Binder, MembersInjector, Optional, and
+  Multibinder.
+- Clock, Filesystem, Console (including TTY/PTY), and DateTimeService test
+  doubles.
+- Reflection, SerDe, network clients, and Command.
+- Per-injector and process-wide singletons.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Guice-style dependency injection for Python: type-based constructor injection,
 scopes, qualified keys, and built-in test doubles. Zero runtime dependencies.
 Python 3.8+.
 
-**Docs:** [https://rl337.org/pyiv/](https://rl337.org/pyiv/)
+**Docs:** [https://rl337.org/pyiv/](https://rl337.org/pyiv/) ·
+**Changelog:** [https://rl337.org/pyiv/changelog.html](https://rl337.org/pyiv/changelog.html)
 
 ## Install
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,8 @@ Both are attached to the GitHub Release. pyiv is not on PyPI yet; install a tagg
 pip install git+https://github.com/rl337/pyiv.git@v<version>
 ```
 
+User-facing notes for a version live in `CHANGELOG.md`. Put new bullets under **Unreleased** in the same PR as the change; after the auto-bump, move them to `## X.Y.Z`. GitHub Release bodies should match those bullets, not a squash commit.
+
 ## Release Artifacts
 
 Release artifacts are:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,2 @@
+.. include:: ../CHANGELOG.md
+   :parser: myst_parser.sphinx_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",  # Support for Google/NumPy style docstrings
+    "myst_parser",  # CHANGELOG.md on the changelog page
 ]
 
 # Autodoc settings
@@ -83,7 +84,12 @@ intersphinx_mapping = {
 htmlhelp_basename = "pyivdoc"
 
 # Exclude patterns
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
+
+# Changelog is included from ../CHANGELOG.md; do not treat every .md as a page.
+source_suffix = {
+    ".rst": "restructuredtext",
+}
 
 # Master document
 master_doc = "index"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ mocking the world.
    <div style="margin: 20px 0; padding: 15px; background: #e8f4f8; border-left: 4px solid #0066cc; border-radius: 4px;">
    <strong>Quick Links:</strong>
    <a href="https://github.com/rl337/pyiv" style="margin-left: 15px; color: #0066cc; text-decoration: none; font-weight: 500;">GitHub</a>
+   <a href="changelog.html" style="margin-left: 15px; color: #0066cc; text-decoration: none; font-weight: 500;">Changelog</a>
    <a href="https://github.com/rl337/pyiv/blob/main/README.md" style="margin-left: 15px; color: #0066cc; text-decoration: none; font-weight: 500;">README</a>
    </div>
 
@@ -165,6 +166,7 @@ docstrings in the ``pyiv`` package; doctests in those docstrings are run in CI.
    :maxdepth: 1
    :caption: Reference
 
+   changelog
    modules
 
 Indices and tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
 docs = [
     "sphinx>=5.0.0",
     "sphinx-rtd-theme>=1.0.0",
+    "myst-parser>=2.0.0,<3",  # <3 keeps Python 3.8; used to render CHANGELOG.md
 ]
 
 [project.urls]
@@ -47,6 +48,7 @@ Homepage = "https://github.com/rl337/pyiv"
 Documentation = "https://rl337.org/pyiv/"
 Repository = "https://github.com/rl337/pyiv"
 Issues = "https://github.com/rl337/pyiv/issues"
+Changelog = "https://rl337.org/pyiv/changelog.html"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pyiv"]

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -91,20 +91,19 @@ run_check "Documentation quality" $PYTHON_CMD check_docs_quality.py
 echo ""
 echo -e "${YELLOW}Running: Sphinx documentation build${NC}"
 echo "Command: Building Sphinx documentation"
-# Check if sphinx-build is available
 SPHINX_BUILD="sphinx-build"
-if ! command -v sphinx-build &> /dev/null; then
-    echo -e "${YELLOW}⚠ sphinx-build not found, attempting to install Sphinx...${NC}"
-    # Try to install sphinx and sphinx-rtd-theme
-    if $PYTHON_CMD -m pip install --quiet --user sphinx sphinx-rtd-theme 2>&1; then
-        echo -e "${GREEN}✓ Sphinx installed${NC}"
-        # Add user local bin to PATH if sphinx was installed there
+if ! $PYTHON_CMD -c "import sphinx, myst_parser" &> /dev/null; then
+    echo -e "${YELLOW}⚠ Sphinx docs extras missing, installing .[docs]...${NC}"
+    if $PYTHON_CMD -m pip install --quiet -e ".[docs]" 2>&1; then
+        echo -e "${GREEN}✓ Docs extras installed${NC}"
         if [ -d "$HOME/.local/bin" ]; then
             export PATH="$HOME/.local/bin:$PATH"
-            SPHINX_BUILD="$HOME/.local/bin/sphinx-build"
+        fi
+        if command -v sphinx-build &> /dev/null; then
+            SPHINX_BUILD="$(command -v sphinx-build)"
         fi
     else
-        echo -e "${RED}✗ Failed to install Sphinx. Please install it manually: pip install sphinx sphinx-rtd-theme${NC}"
+        echo -e "${RED}✗ Failed to install docs extras. Please install: pip install -e \".[docs]\"${NC}"
         FAILED=1
     fi
 fi


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` (Keep a Changelog, Unreleased first, condensed 0.2.x history). Sphinx renders the same file at `/changelog.html`.
- Link it from the homepage, README, Reference nav, and `[project.urls]` Changelog.
- Document the upkeep rules in `packaging-docs.mdc` (Unreleased until the auto-bump; user-facing bullets only). No new skill.

## Test plan
- [ ] Docs preview: https://rl337.org/pyiv/branch/docs/changelog/changelog.html
- [ ] Homepage Quick Links includes Changelog; sidebar Reference lists it
- [ ] Skim Unreleased vs 0.2.24 / 0.2.22 / 0.2.21 for tone (user-facing, not squash commits)
- [ ] `pyproject.toml` Changelog URL is https://rl337.org/pyiv/changelog.html
- [ ] Production site unchanged until merge
